### PR TITLE
should not add / implicit to _escaped_fragment_

### DIFF
--- a/lib/mean-seo.js
+++ b/lib/mean-seo.js
@@ -41,7 +41,7 @@ module.exports = function SEO(options) {
 
 		//If the request came from a crawler
 		if (escapedFragment) {
-			var url = req.protocol + '://' + req.get('host') + req.path + '#!/' + escapedFragment;
+			var url = req.protocol + '://' + req.get('host') + req.path + '#!' + escapedFragment;
 
 			cache.get(escapedFragment, function(err, page) {
 				if (err) {


### PR DESCRIPTION
As far as I can understand from googles spesification, the crawler does not remove the first slash after #! when creating `_escaped_fragment_` urls.

In other words:
# !/some/url -> `?_escaped_fragment_=/some/url`
