### PR TITLE
Solved: _scaped_fragment_ now doesn't add a slash

### DIFF
--- a/lib/mean-seo.js
+++ b/lib/mean-seo.js
@@ -44,7 +44,7 @@ module.exports = function SEO(options) {
       var url, key;
       if (escapedFragment.length > 0) {
         // If the request is in # style.
-        url = req.protocol + '://' + req.get('host') + req.path + '#!/' + escapedFragment;
+        url = req.protocol + '://' + req.get('host') + req.path + '#!' + escapedFragment;
         // Use the escapedFragment as the key.
         key = escapedFragment;
       } else {
@@ -63,7 +63,7 @@ module.exports = function SEO(options) {
 						if (err) {
 							next(err);
 						} else {
-							//Save page to cache 
+							//Save page to cache
 							cache.set(key, html, function(err, res) {
 								if (err) {
 									next(err);
@@ -75,7 +75,7 @@ module.exports = function SEO(options) {
 						}
 					});
 				} else {
-					//If page was found in cache, output the result					
+					//If page was found in cache, output the result
 					res.send(page.content);
 				}
 			});


### PR DESCRIPTION
Solved a bug that provokes that PhantomJS open the urls with the following format: http://example.com/#!//path/to/route